### PR TITLE
[fix]username重複時にユーザーにメッセージを表示

### DIFF
--- a/app/account/account-form.tsx
+++ b/app/account/account-form.tsx
@@ -65,8 +65,18 @@ export default function AccountForm({ user }: { user: User | null }) {
         updated_at: new Date().toISOString(),
         bio,
       });
-      if (error) throw error;
-      alert("Profile updated!");
+      if (error) {
+        if (error.code === "23505") {
+          alert(
+            "そのユーザー名はすでに使用されています。別のユーザー名を選択してください。",
+          );
+        } else {
+          console.error(error);
+          alert("プロフィールの更新中にエラーが発生しました。");
+        }
+        return;
+      }
+      alert("プロフィールが更新されました");
     } finally {
       setLoading(false);
     }

--- a/app/insertUserName/app.tsx
+++ b/app/insertUserName/app.tsx
@@ -18,7 +18,14 @@ const InsertUserNameApp = ({ user_id }: props) => {
       alert("ユーザー名は英数字のみ使用できます");
       return;
     }
-    await insertUsername(user_id, username);
+    const { error } = await insertUsername(user_id, username);
+    if (error) {
+      alert(
+        "そのユーザー名はすでに使用されています。別のユーザー名を選択してください。",
+      );
+      return;
+    }
+
     router.push("/account");
   };
   return (


### PR DESCRIPTION
ユーザー名が重複した場合、ユーザーへメッセージも表示されず更新無効の処理がされるのでそれを通知する close #25 