### PR TITLE
[fix]usernameの登録を募集やコメントを入力する前に必須化する

### DIFF
--- a/app/createRecruitment/page.tsx
+++ b/app/createRecruitment/page.tsx
@@ -16,6 +16,13 @@ const createRecruitment = async () => {
   }
 
   const UserProfile = await fetchProfile(user.id || "");
+  if (!UserProfile.data) {
+    redirect("/login");
+  }
+  if (!UserProfile.data.username) {
+    redirect("/insertUserName");
+  }
+
   const user_id = UserProfile.data?.id || "";
 
   return (

--- a/app/recruitment/[id]/page.tsx
+++ b/app/recruitment/[id]/page.tsx
@@ -7,6 +7,7 @@ import CommentApp from "@/app/components/comment/app";
 import { createClient } from "@/utils/supabase/server";
 import Link from "next/link";
 import DeleteButton from "./deleteButton";
+import { redirect } from "next/navigation";
 
 interface Params {
   id: number;
@@ -28,7 +29,9 @@ const recruitment = async ({ params }: { params: Params }) => {
     userId = user.id;
     username = (await fetchProfile(userId)).data?.username;
   }
-
+  if (!username) {
+    redirect("/insertUserName");
+  }
   if (!data) {
     return <div>募集が見つかりませんでした</div>;
   }


### PR DESCRIPTION
募集やコメントの段階でusernameの登録を検知していなかったため名無しでの投稿ができてしまった
改善のため`/createRecruitment`ページと`/recruitment/[id]`ページの前にusernameが登録されているかどうか確認する
ない場合は`/insertUserName`ページへ自動で遷移する
close #29 