### PR TITLE
[fix]SQLのトリガー名の修正

### DIFF
--- a/sql/002recruitments.sql
+++ b/sql/002recruitments.sql
@@ -30,10 +30,10 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
-CREATE TRIGGER trigger_update_groups
+CREATE TRIGGER trigger_update_recruitments
 BEFORE UPDATE ON recruitments
 FOR EACH ROW EXECUTE FUNCTION update_timestamp();
 
-CREATE TRIGGER trigger_update_chats
+CREATE TRIGGER trigger_update_comments
 BEFORE UPDATE ON comments
 FOR EACH ROW EXECUTE FUNCTION update_timestamp();


### PR DESCRIPTION
SQLファイル、002recruitmentsのテーブル名とトリガー名が不一致だったので修正
close #45 