### PR TITLE
[fix]テストのモック漏れ修正

### DIFF
--- a/test/app/MainPage.test.tsx
+++ b/test/app/MainPage.test.tsx
@@ -1,8 +1,9 @@
-import { describe, expect, test } from "vitest";
+import { describe, expect, test, vi } from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
 import Home from "../../app/page";
 import List from "../../components/mainPage/MainPageList";
-import { mockRecruitments } from "../mocks/mockData";
+import { mockRecruitmentsWithProfiles } from "../mocks/mockData";
+import * as recruitmentFunctions from "@/lib/supabase_function/recruitment";
 
 describe(Home, () => {
   test("初期レンダリングが行われる", () => {
@@ -21,11 +22,17 @@ describe(Home, () => {
 
 describe(List, () => {
   test("各募集のタイトル、説明が表示される", async () => {
+    // getRecruitmentList関数をモック
+    vi.spyOn(recruitmentFunctions, "getRecruitmentList").mockResolvedValue({
+      data: mockRecruitmentsWithProfiles,
+      error: null,
+    });
+
     render(<List />);
 
-    // MSWでモックされたデータが表示されることを確認
+    // モックされたデータが表示されることを確認
     await waitFor(() => {
-      mockRecruitments.slice(0, 10).forEach((recruitment) => {
+      mockRecruitmentsWithProfiles.slice(0, 10).forEach((recruitment) => {
         expect(screen.getByText(recruitment.title)).toBeInTheDocument();
         expect(screen.getByText(recruitment.explanation)).toBeInTheDocument();
       });

--- a/test/integration/navigation.test.tsx
+++ b/test/integration/navigation.test.tsx
@@ -5,7 +5,15 @@ vi.mock("@/lib/supabase_function/profile", () => ({
   fetchProfile: vi.fn(),
 }));
 
-import { beforeEach, describe, expect, type Mock, test, vi } from "vitest";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  type Mock,
+  test,
+  vi,
+} from "vitest";
 import { render, screen } from "@testing-library/react";
 import Navigation from "@/components/navigation/Navigation";
 import { createClient } from "@/utils/supabase/server";
@@ -18,6 +26,11 @@ describe("navigation", () => {
   beforeEach(() => {
     mockedCreateClient.mockClear();
     mockedFetchProfile.mockClear();
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.mocked(console.error).mockRestore();
   });
   test("ユーザー未ログイン状態の確認", async () => {
     mockedCreateClient.mockReturnValue({

--- a/test/mainPage.test.tsx
+++ b/test/mainPage.test.tsx
@@ -1,8 +1,9 @@
-import { describe, expect, test } from "vitest";
+import { describe, expect, test, vi } from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
 import Home from "../app/page";
 import List from "../components/mainPage/MainPageList";
-import { mockRecruitments } from "./mocks/mockData";
+import { mockRecruitmentsWithProfiles } from "./mocks/mockData";
+import * as recruitmentFunctions from "@/lib/supabase_function/recruitment";
 
 describe(Home, () => {
   test("初期レンダリングが行われる", () => {
@@ -21,11 +22,17 @@ describe(Home, () => {
 
 describe(List, () => {
   test("各募集のタイトル、説明が表示される", async () => {
+    // getRecruitmentList関数をモック
+    vi.spyOn(recruitmentFunctions, "getRecruitmentList").mockResolvedValue({
+      data: mockRecruitmentsWithProfiles,
+      error: null,
+    });
+
     render(<List />);
 
-    // MSWでモックされたデータが表示されることを確認
+    // モックされたデータが表示されることを確認
     await waitFor(() => {
-      mockRecruitments.slice(0, 10).forEach((recruitment) => {
+      mockRecruitmentsWithProfiles.slice(0, 10).forEach((recruitment) => {
         expect(screen.getByText(recruitment.title)).toBeInTheDocument();
         expect(screen.getByText(recruitment.explanation)).toBeInTheDocument();
       });

--- a/test/mocks/mockData.ts
+++ b/test/mocks/mockData.ts
@@ -1,5 +1,7 @@
+import type { Recruitment, RecruitmentWithProfile } from "@/types/supabase/types";
+
 // Recruitmentsのモックデータ（profilesなし）
-export const mockRecruitments = [
+export const mockRecruitments: Recruitment[] = [
   { 
     id: 1, 
     user_id: 'test-user-1', 
@@ -23,7 +25,7 @@ export const mockRecruitments = [
 ];
 
 // profiles付きRecruitmentsのモックデータ
-export const mockRecruitmentsWithProfiles = [
+export const mockRecruitmentsWithProfiles: RecruitmentWithProfile[] = [
   { 
     id: 1, 
     user_id: 'test-user-1', 
@@ -33,10 +35,8 @@ export const mockRecruitmentsWithProfiles = [
     status: '募集中', 
     created_at: '2025-05-27T12:00:00Z', 
     updated_at: '2025-05-27T12:00:00Z',
-    profiles: {
-      avatar_url: 'test-avatar.jpg',
-      username: 'testuser1'
-    }
+    avatar_url: '/test-avatar.jpg',
+    username: 'testuser1'
   },
   { 
     id: 2, 
@@ -47,9 +47,7 @@ export const mockRecruitmentsWithProfiles = [
     status: '対応中', 
     created_at: '2025-05-27T13:00:00Z', 
     updated_at: '2025-05-27T13:00:00Z',
-    profiles: {
-      avatar_url: 'test-avatar2.jpg',
-      username: 'testuser2'
-    }
+    avatar_url: '/test-avatar2.jpg',
+    username: 'testuser2'
   },
 ]; 

--- a/test/setup/setup.ts
+++ b/test/setup/setup.ts
@@ -1,0 +1,28 @@
+import { vi } from "vitest";
+import { mockRecruitmentsWithProfiles } from "../mocks/mockData";
+
+vi.mock("@/utils/supabase/client", () => ({
+  createClient: vi.fn(() => ({
+    from: vi.fn(() => ({
+      select: vi.fn().mockReturnThis(),
+      order: vi.fn().mockReturnThis(),
+      insert: vi.fn().mockReturnThis(),
+      update: vi.fn().mockReturnThis(),
+      delete: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      single: vi.fn().mockResolvedValue({ data: {}, error: null }),
+      data: mockRecruitmentsWithProfiles, // mockRecruitmentsWithProfiles を使用
+    })),
+    auth: {
+      getUser: vi.fn().mockResolvedValue({ data: { user: { id: "123" } } }),
+    },
+    storage: {
+      from: vi.fn(() => ({
+        upload: vi.fn().mockResolvedValue({ data: { path: "test-path" }, error: null }),
+        download: vi.fn().mockResolvedValue({ data: new Blob(), error: null }),
+        remove: vi.fn().mockResolvedValue({ data: {}, error: null }),
+        getPublicUrl: vi.fn().mockReturnValue({ data: { publicUrl: "http://example.com/avatar.png" } }),
+      })),
+    },
+  })),
+}));

--- a/test/setup/setup.ts
+++ b/test/setup/setup.ts
@@ -1,27 +1,60 @@
 import { vi } from "vitest";
-import { mockRecruitmentsWithProfiles } from "../mocks/mockData";
 
 vi.mock("@/utils/supabase/client", () => ({
   createClient: vi.fn(() => ({
     from: vi.fn(() => ({
       select: vi.fn().mockReturnThis(),
-      order: vi.fn().mockReturnThis(),
+      order: vi.fn().mockResolvedValue({ data: [], error: null }),
       insert: vi.fn().mockReturnThis(),
       update: vi.fn().mockReturnThis(),
       delete: vi.fn().mockReturnThis(),
       eq: vi.fn().mockReturnThis(),
       single: vi.fn().mockResolvedValue({ data: {}, error: null }),
-      data: mockRecruitmentsWithProfiles, // mockRecruitmentsWithProfiles を使用
+      data: [],
     })),
     auth: {
       getUser: vi.fn().mockResolvedValue({ data: { user: { id: "123" } } }),
     },
     storage: {
       from: vi.fn(() => ({
-        upload: vi.fn().mockResolvedValue({ data: { path: "test-path" }, error: null }),
+        upload: vi
+          .fn()
+          .mockResolvedValue({ data: { path: "test-path" }, error: null }),
         download: vi.fn().mockResolvedValue({ data: new Blob(), error: null }),
         remove: vi.fn().mockResolvedValue({ data: {}, error: null }),
-        getPublicUrl: vi.fn().mockReturnValue({ data: { publicUrl: "http://example.com/avatar.png" } }),
+        getPublicUrl: vi
+          .fn()
+          .mockReturnValue({ data: { publicUrl: "http://example.com/avatar.png" } }),
+      })),
+    },
+  })),
+}));
+
+vi.mock("@/utils/supabase/server", () => ({
+  createClient: vi.fn(() => ({
+    from: vi.fn(() => ({
+      select: vi.fn().mockReturnThis(),
+      order: vi.fn().mockResolvedValue({ data: [], error: null }),
+      insert: vi.fn().mockReturnThis(),
+      update: vi.fn().mockReturnThis(),
+      delete: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      single: vi.fn().mockResolvedValue({ data: {}, error: null }),
+      data: [],
+    })),
+    auth: {
+      getUser: vi.fn().mockResolvedValue({ data: { user: { id: "123" } } }),
+    },
+    storage: {
+      from: vi.fn(() => ({
+        upload: vi
+          .fn()
+          .mockResolvedValue({ data: { path: "test-path" }, error: null }),
+        download: vi.fn().mockResolvedValue({ data: new Blob(), error: null }),
+        remove: vi.fn().mockResolvedValue({ data: {}, error: null }),
+        getPublicUrl: vi
+          .fn()
+          .mockReturnValue({ data: { publicUrl: "http://example.com/avatar.png" } }),
       })),
     },
   })),

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -11,7 +11,7 @@ export default defineConfig({
     test:{
         globals: true,
         environment: "happy-dom",
-        setupFiles: ["./vitest.setup.ts"],
+        setupFiles: ["./vitest.setup.ts", "./test/setup/setup.ts"],
         coverage: {
       provider: 'v8',
       reportsDirectory: './coverage',


### PR DESCRIPTION
vitestのテスト環境でモックから漏れている部分があったので修正
supabaseのクライアント側(`@/utils/supabase/client`)とサーバー側(`@/utils/supabase/server`)の設定を共通モックとしてsetup.tsに追加する

consoleも漏れていたのでspyで対応する

close #63 