### PR TITLE
[fix]vitestからのReactに関する警告の解消

### DIFF
--- a/components/recruitment/comment/CommentList.tsx
+++ b/components/recruitment/comment/CommentList.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { DEFAULT_AVATAR_URL } from "@/lib/supabase_function/profile";
 import styles from "./comment.module.css";
 import Image from "next/image";
 import { CiClock2 } from "react-icons/ci";
@@ -17,7 +18,7 @@ const CommentList = ({ commentList }: Props) => {
           <p className={styles.comment_text}>{comment.text}</p>
           <div className={styles.comment_user}>
             <Image
-              src={comment.avatar_url}
+              src={comment.avatar_url || DEFAULT_AVATAR_URL}
               alt="avatar"
               width={20}
               height={20}

--- a/test/app/AccountForm.test.tsx
+++ b/test/app/AccountForm.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, test, afterEach, vi } from "vitest";
-import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import { act, render, screen, waitFor, fireEvent } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import AccountForm from "../../app/account/account-form";
 import { User } from "@supabase/supabase-js";
@@ -146,7 +146,9 @@ describe("AccountForm", () => {
     );
 
     // Act: API呼び出しを成功させる
-    await resolveUpsert!({ error: null });
+    await act(async () => {
+      await resolveUpsert!({ error: null });
+    });
 
     // Assert: 更新後のUIとアラートを検証
     await waitFor(() => {

--- a/test/app/MainPage.test.tsx
+++ b/test/app/MainPage.test.tsx
@@ -5,16 +5,22 @@ import List from "../../components/mainPage/MainPageList";
 import { mockRecruitments } from "../mocks/mockData";
 
 describe(Home, () => {
-  test("初期レンダリングが行われる", () => {
+  test("初期レンダリングが行われる", async () => {
     render(<Home />);
-    expect(screen.getByText("お手伝いをしましょう")).toBeInTheDocument();
-    expect(screen.getByText("最新募集一覧")).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByText("お手伝いをしましょう")).toBeInTheDocument();
+    });
+    await waitFor(() => {
+      expect(screen.getByText("最新募集一覧")).toBeInTheDocument();
+    });
   });
-  test("タグが正しく表示される", () => {
+  test("タグが正しく表示される", async () => {
     render(<Home />);
     const tags = ["Video", "Text", "Audio", "programming", "design", "other"];
-    tags.forEach((tag) => {
-      expect(screen.getByText(tag)).toBeInTheDocument();
+    await waitFor(() => {
+      tags.forEach((tag) => {
+        expect(screen.getByText(tag)).toBeInTheDocument();
+      });
     });
   });
 });

--- a/test/component/recruitment/comment/CommentApp.test.tsx
+++ b/test/component/recruitment/comment/CommentApp.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, test, vi } from "vitest";
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import CommentApp from "@/components/recruitment/comment/CommentApp";
 
 const mockProps = {
@@ -18,15 +18,17 @@ const mockPropsuserNull = {
 describe("CommentApp Component", () => {
   test("コメントアプリが正しくレンダリングされる", async () => {
     render(<CommentApp {...mockProps} />);
-    expect(screen.getByText("コメントを投稿:")).toBeInTheDocument();
-    expect(screen.getByRole("textbox")).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "投稿" })).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByText("コメントを投稿:")).toBeInTheDocument();
+      expect(screen.getByRole("textbox")).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "投稿" })).toBeInTheDocument();
+    });
   });
 
   test("投稿ボタンをクリックするとコメントが追加される", async () => {
     render(<CommentApp {...mockProps} />);
     window.alert = vi.fn();
-    const textarea = screen.getByRole("textbox");
+    const textarea = await screen.findByRole("textbox");
     const button = screen.getByRole("button", { name: "投稿" });
     fireEvent.change(textarea, { target: { value: "テストコメント" } });
     fireEvent.click(button);
@@ -34,16 +36,20 @@ describe("CommentApp Component", () => {
   });
   test("ユーザーが未ログインの場合、テキストエリアと投稿ボタンが表示されない", async () => {
     render(<CommentApp {...mockPropsuserNull} />);
-    expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
-    expect(
-      screen.queryByRole("button", { name: "投稿" }),
-    ).not.toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole("button", { name: "投稿" }),
+      ).not.toBeInTheDocument();
+    });
   });
   test("未ログインの場合にログインとユーザーネーム登録のリンクが表示される", async () => {
     render(<CommentApp {...mockPropsuserNull} />);
-    const loginLink = screen.getByText("ログイン").closest("a");
-    const registerLink = screen.getByText("ユーザーネーム").closest("a");
-    expect(loginLink).toHaveAttribute("href", "/login");
-    expect(registerLink).toHaveAttribute("href", "/insertUserName");
+    await waitFor(() => {
+      const loginLink = screen.getByText("ログイン").closest("a");
+      const registerLink = screen.getByText("ユーザーネーム").closest("a");
+      expect(loginLink).toHaveAttribute("href", "/login");
+      expect(registerLink).toHaveAttribute("href", "/insertUserName");
+    });
   });
 });

--- a/test/integration/ChangeRecruitment.test.tsx
+++ b/test/integration/ChangeRecruitment.test.tsx
@@ -26,7 +26,7 @@ vi.mock("@/utils/supabase/client", () => ({
         }),
         upload: vi.fn().mockResolvedValue({ error: null }),
         getPublicUrl: vi.fn((path) => ({
-          data: { publicUrl: `https://example.com/avatars/${path}` },
+          data: { publicUrl: path ? `https://example.com/avatars/${path}` : "/default.png" },
         })),
       }),
     },
@@ -62,10 +62,8 @@ type CommentData = {
   recruitment_id: number;
   text: string;
   created_at: string;
-  profile: {
-    username: string | null;
-    avatar_url: string | null;
-  };
+  username: string | null;
+  avatar_url: string | null;
 };
 
 // --- 共通モック関数 ---
@@ -550,7 +548,8 @@ describe("recruitment/[id] test", () => {
         recruitment_id: 1,
         text: "初めてのコメント",
         created_at: new Date().toISOString(),
-        profile: { username: "testuser", avatar_url: null },
+        username: "testuser",
+        avatar_url: null,
       },
     ]);
 

--- a/test/integration/ChangeRecruitment.test.tsx
+++ b/test/integration/ChangeRecruitment.test.tsx
@@ -267,7 +267,9 @@ describe("recruitment/[id] test", () => {
     });
     render(rendered);
 
-    expect(screen.queryByText("内容を編集する")).not.toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.queryByText("内容を編集する")).not.toBeInTheDocument();
+    });
   });
 
   test("編集ボタンをクリックして募集内容を更新し、表示に反映される", async () => {
@@ -443,9 +445,11 @@ describe("recruitment/[id] test", () => {
     render(rendered);
 
     // 削除ボタンが表示されないことを確認
-    expect(
-      screen.queryByRole("button", { name: "削除" }),
-    ).not.toBeInTheDocument();
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("button", { name: "削除" }),
+      ).not.toBeInTheDocument();
+    });
   });
   test("ユーザーがログインしていない場合、/loginにリダイレクトされる", async () => {
     // ログインしていない状態を直接モックする
@@ -568,6 +572,8 @@ describe("recruitment/[id] test", () => {
     await waitFor(() => {
       expect(screen.getByText("新しいコメント")).toBeInTheDocument();
     });
-    expect(screen.getByText("初めてのコメント")).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByText("初めてのコメント")).toBeInTheDocument();
+    });
   });
 });

--- a/test/integration/ChangeRecruitment.test.tsx
+++ b/test/integration/ChangeRecruitment.test.tsx
@@ -120,12 +120,13 @@ const mockComment = (
   initialComments: CommentData[] = [],
   addCommentImpl?: any,
 ) => {
+  let commentId = 2;
   vi.doMock("@/lib/supabase_function/comment", () => ({
     addComment: addCommentImpl
       ? addCommentImpl
       : async (userId: string, recruitmentId: number, text: string) => ({
           data: {
-            id: 2,
+            id: commentId++,
             user_id: userId,
             recruitment_id: recruitmentId,
             text,

--- a/test/mainPage.test.tsx
+++ b/test/mainPage.test.tsx
@@ -5,16 +5,22 @@ import List from "../components/mainPage/MainPageList";
 import { mockRecruitments } from "./mocks/mockData";
 
 describe(Home, () => {
-  test("初期レンダリングが行われる", () => {
+  test("初期レンダリングが行われる", async () => {
     render(<Home />);
-    expect(screen.getByText("お手伝いをしましょう")).toBeInTheDocument();
-    expect(screen.getByText("最新募集一覧")).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByText("お手伝いをしましょう")).toBeInTheDocument();
+    });
+    await waitFor(() => {
+      expect(screen.getByText("最新募集一覧")).toBeInTheDocument();
+    });
   });
-  test("タグが正しく表示される", () => {
+  test("タグが正しく表示される", async () => {
     render(<Home />);
     const tags = ["Video", "Text", "Audio", "programming", "design", "other"];
-    tags.forEach((tag) => {
-      expect(screen.getByText(tag)).toBeInTheDocument();
+    await waitFor(() => {
+      tags.forEach((tag) => {
+        expect(screen.getByText(tag)).toBeInTheDocument();
+      });
     });
   });
 });


### PR DESCRIPTION
テスト実行時に表示されるReactに関する各警告の修正

1. act() の警告
非同期処理の見直しとactを使用して解消する。

2. key propの警告
commentIdの値が"2"で固定されておりコメントを追加する処理に対応できていないので、値をユニークなものにし対応する。

3. imgタグのsrc属性に関する警告
imgタグに空文字が挿入されるパターンがあったので、デフォルトの値が入るように修正する。

close #65