### PR TITLE
[fix]formatDatetimeの引数名の変更とエラーハンドリング

### DIFF
--- a/utils/date.ts
+++ b/utils/date.ts
@@ -7,6 +7,12 @@ dayjs.extend(timezone)
 
 
 export const formatDatetime = (date: string | null) => {
-  if (!date) return "";
-  return dayjs.utc(date).tz('Asia/Tokyo').format('YYYY/MM/DD HH:mm')
+  if (!date) {
+    return ""
+  }
+  const d = dayjs.utc(date)
+  if (!d.isValid()) {
+    return ""
+  }
+  return d.tz('Asia/Tokyo').format('YYYY/MM/DD HH:mm')
 }

--- a/utils/date.ts
+++ b/utils/date.ts
@@ -6,7 +6,7 @@ dayjs.extend(utc)
 dayjs.extend(timezone)
 
 
-export const formatDatetime = (created_at: string | null) => {
-  if (!created_at) return "";
-  return dayjs.utc(created_at).tz('Asia/Tokyo').format('YYYY/MM/DD HH:mm')
+export const formatDatetime = (date: string | null) => {
+  if (!date) return "";
+  return dayjs.utc(date).tz('Asia/Tokyo').format('YYYY/MM/DD HH:mm')
 }


### PR DESCRIPTION
formatDatetimeを汎用的に使うために引数名を変更し、不正な数値や存在しない日付を入力された際のエラーハンドリングがないので追加する。

dayjsの.isValidを使用して正しい数値か確認する

close #70  