### PR TITLE
[fix]pagination.test.tsxで失敗するテストについて修正

### DIFF
--- a/test/component/recruitment/Pagination.test.tsx
+++ b/test/component/recruitment/Pagination.test.tsx
@@ -8,7 +8,7 @@ describe("Pagination", () => {
       <Pagination
         currentPage={1}
         hasNextPage={true}
-        tag={"Video"}
+        basePath={"/category/Video"}
         filterQuery={""}
       />,
     );
@@ -20,7 +20,7 @@ describe("Pagination", () => {
       <Pagination
         currentPage={2}
         hasNextPage={true}
-        tag={"Video"}
+        basePath={"/category/Video"}
         filterQuery={""}
       />,
     );
@@ -32,7 +32,7 @@ describe("Pagination", () => {
       <Pagination
         currentPage={2}
         hasNextPage={true}
-        tag={"Video"}
+        basePath={"/category/Video"}
         filterQuery={""}
       />,
     );
@@ -46,7 +46,7 @@ describe("Pagination", () => {
       <Pagination
         currentPage={3}
         hasNextPage={false}
-        tag={"Video"}
+        basePath={"/category/Video"}
         filterQuery={""}
       />,
     );
@@ -57,7 +57,7 @@ describe("Pagination", () => {
       <Pagination
         currentPage={1}
         hasNextPage={true}
-        tag={"Video"}
+        basePath={"/category/Video"}
         filterQuery={""}
       />,
     );
@@ -74,7 +74,7 @@ describe("Pagination", () => {
       <Pagination
         currentPage={0}
         hasNextPage={false}
-        tag={""}
+        basePath={""}
         filterQuery={""}
       />,
     );


### PR DESCRIPTION
`pagination.test.tsx`にて`Pagination.tsx`の仕様変更によりテストが失敗するようになったのでテストの方を修正する。


修正：propsを`Pagination.tsx`のページに合わせtagからbasePathに修正