### PR TITLE
[fix]募集のカード内で長いタイトルがはみ出さないようにする

### DIFF
--- a/components/profiles/user/userRecruitmentList.module.css
+++ b/components/profiles/user/userRecruitmentList.module.css
@@ -23,10 +23,16 @@
   background-color: wheat;
 }
 .list_title {
+  max-width: 80%;
   font-size: 20px;
   font-weight: bold;
   margin-bottom: 10px;
   border-bottom: 3px solid #ccc;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  -webkit-line-clamp: 2;
+  text-overflow: ellipsis;
 }
 .list_item {
   display: flex;

--- a/components/recruitment/card/recruitmentCard.module.css
+++ b/components/recruitment/card/recruitmentCard.module.css
@@ -36,6 +36,13 @@
   -webkit-line-clamp: 2;
   text-overflow: ellipsis;
 }
+.list_title {
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  -webkit-line-clamp: 2;
+  text-overflow: ellipsis;
+}
 .info_status {
   width: fit-content;
   margin: 5px 10px;


### PR DESCRIPTION
トップページ等の募集カードで長い内容のタイトルをつけるとカードからはみ出てしまうので、二行を超えたら省略されるようにする。